### PR TITLE
Improve the command order for "start.sh"

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,18 +13,25 @@ if [[ (-z "${CODABIX_INITIALIZED}" ) && (! -f "${CODABIX_PROJECT_DIR}/codabixdb.
 
     echo "admin pw: ${CODABIX_ADMIN_PASSWORD}"
 
-    codabix init --project-directory=${CODABIX_PROJECT_DIR}
+    # create the project
+    codabix create --project-directory=${CODABIX_PROJECT_DIR}
 
-    # restore project configuration if environment variable for restore is set
+    # apply basic settings
+    codabix settings "{ \"WebServer\": { \"BindingSettings\": { \"UseLocalPort\": true } } }" --project-directory=${CODABIX_PROJECT_DIR}
+
+    # restore project configuration if environment variable for restore is set (this will keep the current project settings, except for the project name)
     if [ -n "${CODABIX_RESTORE_FILE}" ]; then
         codabix restore ${CODABIX_RESTORE_FILE} --project-directory=${CODABIX_PROJECT_DIR}
     fi
 
-    codabix settings "{ \"WebServer\": { \"BindingSettings\": { \"UseLocalPort\": true } } }" --project-directory=${CODABIX_PROJECT_DIR}
-
+    # set the project name after restoring the backup, as the restore command changes the project name to the one from the backup
     if [ -n "${CODABIX_PROJECT_NAME}" ]; then
         codabix settings "{ \"ProjectName\": \"${CODABIX_PROJECT_NAME}\" }" --project-directory=${CODABIX_PROJECT_DIR}
     fi
+
+    # initialize/upgrade the back-end database
+    codabix init --project-directory=${CODABIX_PROJECT_DIR}
+
     codabix set-admin-password ${CODABIX_ADMIN_PASSWORD} --project-directory=${CODABIX_PROJECT_DIR}
 
     unset ${CODABIX_ADMIN_PASSWORD}


### PR DESCRIPTION
- Avoid unnecessary initialization of the back-end database if a backup is to be restored later (which would delete the database again).
- Ensure the basic settings are set before restoring a backup, e.g. if we later want to use a different back-end database than SQLite.
- Ensure the back-end database is upgraded after restoring a backup, since this is no longer done implicitely when starting the engine (since CoDaBix 1.0.0).