### PR TITLE
Update to v1.0.1, add --upgrade option

### DIFF
--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -4,7 +4,7 @@ COPY qemu-arm-static /usr/bin
 
 FROM base as builder
 
-ENV CODABIX_DOWNLOAD_LINK https://www.codabix.com/_media/downloads/installers/codabix-1.0.0/codabix-linux-arm32-2020-12-11-1.0.0.setup
+ENV CODABIX_DOWNLOAD_LINK https://www.codabix.com/_media/downloads/installers/codabix-1.0.1/codabix-linux-arm32-2020-12-14-1.0.1.setup
 ENV CODABIX_SETUP_FILE /tmp/codabix.setup
 RUN apt-get update && apt-get install -y \
     curl

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,7 +30,7 @@ if [[ (-z "${CODABIX_INITIALIZED}" ) && (! -f "${CODABIX_PROJECT_DIR}/codabixdb.
     fi
 
     # initialize/upgrade the back-end database
-    codabix init --project-directory=${CODABIX_PROJECT_DIR}
+    codabix init --upgrade --project-directory=${CODABIX_PROJECT_DIR}
 
     codabix set-admin-password ${CODABIX_ADMIN_PASSWORD} --project-directory=${CODABIX_PROJECT_DIR}
 

--- a/x64/Dockerfile
+++ b/x64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04 as base
 
 FROM base as builder
 
-ENV CODABIX_DOWNLOAD_LINK https://www.codabix.com/_media/downloads/installers/codabix-1.0.0/codabix-linux-x64-2020-12-11-1.0.0.setup
+ENV CODABIX_DOWNLOAD_LINK https://www.codabix.com/_media/downloads/installers/codabix-1.0.1/codabix-linux-x64-2020-12-14-1.0.1.setup
 ENV CODABIX_SETUP_FILE /tmp/codabix.setup
 RUN apt-get update && apt-get install -y \
     curl


### PR DESCRIPTION
- Update to Codabix v1.0.1.
- Pass the `--upgrade` option to the `codabix init` command (introduced with v1.0.0) to allow to upgrade the back-end database.