### PR TITLE
Update workflow regarding container registry login

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -45,19 +45,19 @@ jobs:
       uses: docker/setup-buildx-action@master
 
     -
-      name: Log in to Docker Hub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      name: Login to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
     -
-      name: Log in to GitHub
-      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: ${{ secrets.PACKAGES_GITHUB_USER }}
-        password: ${{ secrets.PACKAGES_GITHUB_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     -
       name: Build


### PR DESCRIPTION
Try to update workflow to use the `GITHUB_TOKEN` for logging into Github's container registry.