### PR TITLE
Update to using `GITHUB_OUTPUT` environment files

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -31,7 +31,12 @@ jobs:
         then
           TAG="latest";
         fi
-        echo "tags=\"ghcr.io/traeger-gmbh/codabix:${TAG}\"\$'\\n'\"traeger/codabix:${TAG}\"" >> $GITHUB_OUTPUT
+        {
+          echo "tags<<EOFTAGS"
+          echo "ghcr.io/traeger-gmbh/codabix:${TAG}"
+          echo "traeger/codabix:${TAG}"
+          echo "EOFTAGS"
+        } >> "$GITHUB_OUTPUT"
     
     -
       name: Set up QEMU

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -31,7 +31,7 @@ jobs:
         then
           TAG="latest";
         fi
-        echo "tags=\"ghcr.io/traeger-gmbh/codabix:${TAG}"$'\n'"traeger/codabix:${TAG}\"" >> $GITHUB_OUTPUT
+        echo "tags=\"ghcr.io/traeger-gmbh/codabix:${TAG}\"\$'\\n'\"traeger/codabix:${TAG}\"" >> $GITHUB_OUTPUT
     
     -
       name: Set up QEMU

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -31,7 +31,8 @@ jobs:
         then
           TAG="latest";
         fi
-        echo "tags=$(echo "ghcr.io/traeger-gmbh/codabix:${TAG}%0Atraeger/codabix:${TAG}")" >> $GITHUB_OUTPUT
+        echo "tags=\"ghcr.io/traeger-gmbh/codabix:${TAG}
+        traeger/codabix:${TAG}\"" >> $GITHUB_OUTPUT
     
     -
       name: Set up QEMU

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -31,7 +31,7 @@ jobs:
         then
           TAG="latest";
         fi
-        echo ::set-output name=tags::$(echo "ghcr.io/traeger-gmbh/codabix:${TAG}%0Atraeger/codabix:${TAG}") 
+        echo "tags=$(echo "ghcr.io/traeger-gmbh/codabix:${TAG}%0Atraeger/codabix:${TAG}")" >> $GITHUB_OUTPUT
     
     -
       name: Set up QEMU

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -31,8 +31,7 @@ jobs:
         then
           TAG="latest";
         fi
-        echo "tags=\"ghcr.io/traeger-gmbh/codabix:${TAG}
-        traeger/codabix:${TAG}\"" >> $GITHUB_OUTPUT
+        echo "tags=\"ghcr.io/traeger-gmbh/codabix:${TAG}"$'\n'"traeger/codabix:${TAG}\"" >> $GITHUB_OUTPUT
     
     -
       name: Set up QEMU


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Note: This needs a special syntax to embed a newline character in the value. See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

This syntax requires using a delimiter, which musn't occur on a line on its own in the value. Currently, we use `EOFTAGS`.